### PR TITLE
Building issue in Visual Studio - updated trim function to use lambda

### DIFF
--- a/src/ofxParagraph.h
+++ b/src/ofxParagraph.h
@@ -102,10 +102,6 @@ class ofxParagraph{
         inline void drawRightAligned();
     
         static inline std::string &trim(std::string &s) {
-//			s.erase(s.begin(), std::find_if(s.begin(), s.end(),
-//				std::not1(std::ptr_fun<int, int>(std::isspace))));
-//			s.erase(std::find_if(s.rbegin(), s.rend(),
-//				std::not1(std::ptr_fun<int, int>(std::isspace))).base(), s.end());
 			s.erase(s.begin(), std::find_if(s.begin(), s.end(), [](char c) {return !isspace(c); }));
 			s.erase(std::find_if(s.rbegin(), s.rend(), [](char c) {return !isspace(c); }).base(), s.end());
 			return s;

--- a/src/ofxParagraph.h
+++ b/src/ofxParagraph.h
@@ -24,6 +24,7 @@
 #pragma once
 #include <ofGraphics.h>
 #include "ofxSmartFont.h"
+#include <functional>
 
 class ofxParagraph{
     
@@ -101,9 +102,13 @@ class ofxParagraph{
         inline void drawRightAligned();
     
         static inline std::string &trim(std::string &s) {
-            s.erase(s.begin(), std::find_if(s.begin(), s.end(), std::not1(std::ptr_fun<int, int>(std::isspace))));
-            s.erase(std::find_if(s.rbegin(), s.rend(), std::not1(std::ptr_fun<int, int>(std::isspace))).base(), s.end());
-            return s;
+//			s.erase(s.begin(), std::find_if(s.begin(), s.end(),
+//				std::not1(std::ptr_fun<int, int>(std::isspace))));
+//			s.erase(std::find_if(s.rbegin(), s.rend(),
+//				std::not1(std::ptr_fun<int, int>(std::isspace))).base(), s.end());
+			s.erase(s.begin(), std::find_if(s.begin(), s.end(), [](char c) {return !isspace(c); }));
+			s.erase(std::find_if(s.rbegin(), s.rend(), [](char c) {return !isspace(c); }).base(), s.end());
+			return s;
         }
     
 };

--- a/src/ofxParagraph.h
+++ b/src/ofxParagraph.h
@@ -24,7 +24,6 @@
 #pragma once
 #include <ofGraphics.h>
 #include "ofxSmartFont.h"
-#include <functional>
 
 class ofxParagraph{
     


### PR DESCRIPTION
ofxParagraph doesn't build on Windows (VS2015) because of issues in the overload of `std::isspace` in the `static inline std::string &trim(std::string &s)` function of `ofxParagraph.h`.

Since `std::ptr_fun` is getting deprecated in C++11, this PR get rid of the not1 and ptr_fun calls by using a lambda, replacing:

```
s.erase(s.begin(), std::find_if(s.begin(), s.end(), std::not1(std::ptr_fun<int, int>(std::isspace))));
s.erase(std::find_if(s.rbegin(), s.rend(), std::not1(std::ptr_fun<int, int>(std::isspace))).base(), s.end());
```

with

```
s.erase(s.begin(), std::find_if(s.begin(), s.end(), [](char c) {return !isspace(c); }));
s.erase(std::find_if(s.rbegin(), s.rend(), [](char c) {return !isspace(c); }).base(), s.end());
```

Commit checked on OSX and Windows. Compiles and performs as expected.
